### PR TITLE
Update README.md: typos and formatting

### DIFF
--- a/sample-kubernetes/README.md
+++ b/sample-kubernetes/README.md
@@ -2,7 +2,7 @@ Kubernetes sample ![Logo][1]
 ==============
 
 This sample uses Kubernetes as container platform and deploys both application and integration tests as Pods in Kubernetes.
-Read about the Citrus Kubernetes integration in [reference guide][4]
+Read about the Citrus Kubernetes integration in the [reference guide][4]
 
 Objectives
 ---------
@@ -16,54 +16,55 @@ The sample uses the Fabric8 Maven plugins for Kubernetes resource generation and
 order to deploy the application to Kubernetes. The todo-list application defines a deployment with a service and a pod running within a replication 
 set. The Fabric8 Maven plugin configuration looks like follows.
   
-    <plugin>
-        <groupId>io.fabric8</groupId>
-        <artifactId>fabric8-maven-plugin</artifactId>
-        <version>3.2.15</version>
-        <configuration>
-          <mode>kubernetes</mode>
-          <resources>
-            <services>
-              <service>
-                <name>citrus-sample-todo-service</name>
-                <ports>
-                  <port>
-                    <protocol>tcp</protocol>
-                    <port>8080</port>
-                    <targetPort>8080</targetPort>
-                  </port>
-                </ports>
-                <type>NodePort</type>
-              </service>
-            </services>
-          </resources>
-          <verbose>true</verbose>
-          <images>
-            <image>
-              <alias>todo-app</alias>
-              <name>citrus/todo-app:${project.version}</name>
-              <build>
-                <from>fabric8/tomcat-8:latest</from>
-                <tags>
-                  <tag>latest</tag>
-                </tags>
-                <assembly>
-                  <inline>
-                    <files>
-                      <file>
-                        <source>${settings.localRepository}/com/consol/citrus/samples/citrus-sample-todo/${project.version}/citrus-sample-todo-${project.version}.war</source>
-                        <destName>ROOT.war</destName>
-                        <outputDirectory>.</outputDirectory>
-                      </file>
-                    </files>
-                  </inline>
-                </assembly>
-              </build>
-            </image>
-          </images>
-        </configuration>
-    </plugin>
-    
+```xml
+<plugin>
+    <groupId>io.fabric8</groupId>
+    <artifactId>fabric8-maven-plugin</artifactId>
+    <version>3.2.15</version>
+    <configuration>
+      <mode>kubernetes</mode>
+      <resources>
+        <services>
+          <service>
+            <name>citrus-sample-todo-service</name>
+            <ports>
+              <port>
+                <protocol>tcp</protocol>
+                <port>8080</port>
+                <targetPort>8080</targetPort>
+              </port>
+            </ports>
+            <type>NodePort</type>
+          </service>
+        </services>
+      </resources>
+      <verbose>true</verbose>
+      <images>
+        <image>
+          <alias>todo-app</alias>
+          <name>citrus/todo-app:${project.version}</name>
+          <build>
+            <from>fabric8/tomcat-8:latest</from>
+            <tags>
+              <tag>latest</tag>
+            </tags>
+            <assembly>
+              <inline>
+                <files>
+                  <file>
+                    <source>${settings.localRepository}/com/consol/citrus/samples/citrus-sample-todo/${project.version}/citrus-sample-todo-${project.version}.war</source>
+                    <destName>ROOT.war</destName>
+                    <outputDirectory>.</outputDirectory>
+                  </file>
+                </files>
+              </inline>
+            </assembly>
+          </build>
+        </image>
+      </images>
+    </configuration>
+</plugin>
+```
 We define a service *citrus-sample-todo-service* that exposes the API with type *NodePort* on port *8080*. This means that other pods will be able to access the service via 
 
     http://citrus-sample-todo-service:8080
@@ -78,7 +79,7 @@ First of all you need a running Kubernetes platform. Minikube is the best way to
 
 Execute the Fabric8 deployment process via:
 
-    mvn clean package fabric8:resource fabric:build fabric:deploy
+    mvn clean package fabric8:resource fabric8:build fabric8:deploy
      
 This builds the Kubernetes resource configuration, builds the Docker Tomcat 8 image and deploys everything to Kubernetes.
 


### PR DESCRIPTION
I added syntax highlighting to the xml section and most importantly added the missing `8` for the `fabric8` plugin calls (`mvn fabric:build` won't work).