### PR TITLE
Use jetty:run-war instead of jetty:run

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ container is automatically stopped.
 
 You can also start the Jetty container manually by calling:
 
-     mvn jetty:run
+     mvn jetty:run-war
 
 Execute this command in the respective sample folders and you will get a running Jetty Web Server Container with the system under test deployed.
 


### PR DESCRIPTION
jetty:run-war starts the war, whereas jetty:run searches the sources in the module directories